### PR TITLE
Various build system fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -21,11 +24,11 @@
         "nixpkgs-appimagekit": "nixpkgs-appimagekit"
       },
       "locked": {
-        "lastModified": 1619188375,
-        "narHash": "sha256-oQW+9bxdQcdartan+0pe1+bBnxDqzugLEtuP6KA2sBQ=",
+        "lastModified": 1627593882,
+        "narHash": "sha256-3KfL6nGZlXL8vdHWS3NOzswR3Ji56osRMUrQw12/XiE=",
         "owner": "radvendii",
         "repo": "nix-bundle",
-        "rev": "e743fb2ed8b85abd1a6d2aff7cafa9b27d613077",
+        "rev": "5e1e68dab10013871481d922038c6be57da92dc7",
         "type": "github"
       },
       "original": {
@@ -66,11 +69,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1619788849,
-        "narHash": "sha256-0t5lEUEmY9Tss1PvET6Wq7VyRCdlDHCQ9NWZmxtAaY8=",
+        "lastModified": 1719049198,
+        "narHash": "sha256-LcT3+nCqPXs0wwiF8Ue9s1tjKl+qT7MwrCHFIpb5JZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc68eb58bb8d4dc3cfb8896932e6146c45579932",
+        "rev": "f399afc5ef2305bba871adc253a3549f4eb603c1",
         "type": "github"
       },
       "original": {
@@ -84,6 +87,21 @@
         "flake-utils": "flake-utils",
         "nix-bundle": "nix-bundle",
         "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,9 @@
         defaultPackage = packages.game;
         packages = {
           game = import ./nix { inherit nixpkgs system; };
-          darwin-app = import ./darwin-app.nix { inherit nixpkgs system; };
-          windows = import ./windows.nix { inherit nixpkgs system; };
-          flatpak = import ./flatpak.nix { inherit nixpkgs system; };
+          darwin-app = import ./nix/darwin-app.nix { inherit nixpkgs system; };
+          windows = import ./nix/windows.nix { inherit nixpkgs system; };
+          flatpak = import ./nix/flatpak.nix { inherit nixpkgs system; };
           appimage = nix-bundle.bundlers.appimage {
             inherit system;
             target = (oldGlibcPkgs.callPackage ./package.nix { }).overrideAttrs (old: {

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,13 @@ cc = meson.get_compiler('c')
 # find dependencies (depending on host)
 math_lib = cc.find_library('m', required : false)
 opengl_dep = is_windows ? cc.find_library('opengl32', required : true) : dependency('opengl', static : static_deps)
-glu_dep = is_windows ? cc.find_library('glu32', required : true) : dependency('glu', static : static_deps)
+if is_windows
+    glu_dep = cc.find_library('glu32', required : true)
+elif is_darwin
+    glu_dep = opengl_dep
+else
+    glu_dep = dependency('glu', static : static_deps)
+endif
 sdl2_dep = dependency('sdl2', static : static_deps)
 sdl2_mixer_dep = dependency('SDL2_mixer', static : static_deps)
 libconfig_dep = dependency('libconfig', static : static_deps)

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,8 @@
 # subdirectories here, and trying to avoid putting any concerns about what the.
 # host machine is in the subdirectories.
 
-project('MAR1D', 'c')
-
 # make sure we're nice and clean
-add_project_arguments('-Werror',  language: 'c')
+project('MAR1D', 'c', default_options: 'werror=true')
 
 # this project makes extensive use of char subscripts, and i'm proud of it.
 add_project_arguments( '-Wno-char-subscripts', language: 'c')

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "First person Super Mario Bros";
+    mainProgram = "MAR1D";
     longDescription = ''
       The original Super Mario Bros as you've never seen it. Step into Mario's
       shoes in this first person clone of the classic Mario game. True to the
@@ -38,7 +39,7 @@ stdenv.mkDerivation rec {
       You must view the world as mario does, as a one dimensional line.
     '';
     homepage = "https://mar1d.com";
-    license = licenses.agpl3;
+    license = licenses.agpl3Only;
     maintainers = with maintainers; [ taeer ];
     platforms = platforms.unix;
   };

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -1,7 +1,11 @@
 #ifndef _GRAPHICS_H
 #define _GRAPHICS_H
 #include <SDL_opengl.h>
-#include <GL/glu.h>
+#ifdef __APPLE__
+  #include <OpenGL/glu.h>
+#else
+  #include <GL/glu.h>
+#endif
 #include <SDL.h>
 #include "helpers.h"
 #include "objects.h"

--- a/src/menu.h
+++ b/src/menu.h
@@ -2,7 +2,11 @@
 #define _MENU_H
 
 #include <SDL_opengl.h>
-#include <GL/glu.h>
+#if __APPLE__
+  #include <OpenGL/glu.h>
+#else
+  #include <GL/glu.h>
+#endif
 #include <SDL.h>
 #include "helpers.h"
 #include "graphics.h"


### PR DESCRIPTION
Hi there, I see you’re also a Nix user! Unfortunately some assumptions about Nixpkgs’s strange macOS OpenGL setup were baked into the code, so your project couldn’t be built on macOS without Nix, and a pull request I’m working on to clean them up in Nixpkgs broke the build there too. I’ve fixed those issues here, along with a couple others, and will be incorporating the patch into the Nixpkgs package for now.

By the way, it’d technically be better to use `dependency('gl')` instead, because Meson has [special handling for this string](https://mesonbuild.com/Dependencies.html#gl). Unfortunately, because of the aforementioned Nixpkgs OpenGL weirdness, this produces a non‐functional build with the current stable Nixpkgs release. You might want to consider making that change after the current release is out of support, if you spend any time on this codebase in future.